### PR TITLE
Fix:v-footerの位置を固定

### DIFF
--- a/frontend/layouts/default.vue
+++ b/frontend/layouts/default.vue
@@ -66,6 +66,7 @@
           <v-icon color="white">mdi-chevron-up</v-icon>
         </v-btn>
       </transition>
+      <div class="push" />
     </v-main>
     <v-footer>
       <v-card class="py-2 mx-auto" color="rgba(0,0,0,0)" elevation="0">
@@ -175,6 +176,14 @@ export default {
 <style>
 [v-cloak] {
   display: none;
+}
+.v-footer {
+  width: 100%;
+  position: fixed;
+  bottom: 0;
+}
+.push {
+  height: 150px;
 }
 .fade-enter-active,
 .fade-leave-active {


### PR DESCRIPTION
fix #3 

## 概要
アイコンをホバー時にv-footerが動いてしまうため位置を修正

## 修正後
[![Image from Gyazo](https://i.gyazo.com/2778e850396bedb64bfa46a5e17a4298.gif)](https://gyazo.com/2778e850396bedb64bfa46a5e17a4298)

## コメント
footerの位置を固定したことで、v-mainとv-footerがネガティブマージンで重なってしまったため、v-main最下部にdivタグを追加